### PR TITLE
Handle pointer struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ Mkfile.old
 dkms.conf
 
 .local/
+
+# Unit test build artifacts
+test/build/

--- a/src/emb_ext_flash.c
+++ b/src/emb_ext_flash.c
@@ -12,7 +12,7 @@ void emb_ext_flash_write_enable( emb_flash_intf_handle_t *p_intf )
     uint8_t cmd = EXT_FLASH_CMD_WRITE_ENABLE;
 
     // Null check
-    if( !p_intf )
+    if( !p_intf || !p_intf->initialized )
         return;
 
     // Do the transfer
@@ -26,6 +26,25 @@ void emb_ext_flash_write_enable( emb_flash_intf_handle_t *p_intf )
 }
 
 // Pubic functions
+int emb_ext_flash_init_intf( emb_flash_intf_handle_t *p_intf )
+{
+    // Null check
+    if( !p_intf )
+        return -1;
+
+    // Set the initialized flag to 0;
+    p_intf->initialized = 0;
+
+    // Check all of the function pointers, if any are null return -1
+    if( !p_intf->select || !p_intf->deselect || !p_intf->write || !p_intf->read || !p_intf->delay_us )
+        return -1;
+
+    // Set the initialized flag to 1
+    p_intf->initialized = 1;
+
+    return 0;
+}
+
 int emb_ext_flash_get_jedec_id( emb_flash_intf_handle_t *p_intf, uint8_t *manufacturer_id, uint8_t *memory_type, uint8_t *capacity )
 {
     // Build the command and the payload
@@ -33,7 +52,7 @@ int emb_ext_flash_get_jedec_id( emb_flash_intf_handle_t *p_intf, uint8_t *manufa
     uint8_t data[3] = { 0 };
 
     // Null check
-    if( !p_intf )
+    if( !p_intf || !p_intf->initialized )
         return -1;
 
     // Do the transfer
@@ -57,7 +76,7 @@ int emb_ext_flash_read( emb_flash_intf_handle_t *p_intf, uint32_t address, uint8
     uint8_t cmd[4] = { EXT_FLASH_CMD_READ_DATA, ( address >> 16 ) & 0xFF, ( address >> 8 ) & 0xFF, address & 0xFF };
 
     // Null check
-    if( !p_intf )
+    if( !p_intf || !p_intf->initialized )
         return 0;
 
     // Do the transfer
@@ -79,7 +98,7 @@ int emb_ext_flash_write( emb_flash_intf_handle_t *p_intf, uint32_t address, uint
     uint8_t cmd[4] = { EXT_FLASH_CMD_PAGE_PROGRAM, ( address >> 16 ) & 0xFF, ( address >> 8 ) & 0xFF, address & 0xFF };
 
     // Null check
-    if( !p_intf )
+    if( !p_intf || !p_intf->initialized )
         return 0;
 
     // Do the transfer
@@ -102,7 +121,7 @@ int emb_ext_flash_erase( emb_flash_intf_handle_t *p_intf, uint32_t address, uint
     emb_ext_flash_write_enable( p_intf );
 
     // Null check
-    if( !p_intf )
+    if( !p_intf || !p_intf->initialized )
         return -1;
 
     // Determine the most efficient command to use
@@ -134,8 +153,8 @@ int emb_ext_flash_chip_erase( emb_flash_intf_handle_t *p_intf )
     emb_ext_flash_write_enable( p_intf );
 
     // Null check
-    if( !p_intf )
-        return;
+    if( !p_intf || !p_intf->initialized )
+        return -1;
 
     // Build the command
     uint8_t cmd = EXT_FLASH_CMD_CHIP_ERASE;
@@ -160,7 +179,7 @@ uint8_t emb_ext_flash_get_status( emb_flash_intf_handle_t *p_intf )
     uint8_t status = 0;
 
     // Null check
-    if( !p_intf )
+    if( !p_intf || !p_intf->initialized )
         return status;
 
     // Do the transfer
@@ -179,7 +198,7 @@ int emb_ext_flash_sleep( emb_flash_intf_handle_t *p_intf )
     uint8_t cmd = EXT_FLASH_CMD_POWER_DOWN;
 
     // Null check
-    if( !p_intf )
+    if( !p_intf || !p_intf->initialized )
         return -1;
 
     // Do the transfer
@@ -196,7 +215,7 @@ int emb_ext_flash_wake( emb_flash_intf_handle_t *p_intf )
     uint8_t cmd = EXT_FLASH_CMD_RELEASE_POWER_DOWN;
 
     // Null check
-    if( !p_intf )
+    if( !p_intf || !p_intf->initialized )
         return -1;
 
     // Do the transfer

--- a/src/emb_ext_flash.c
+++ b/src/emb_ext_flash.c
@@ -1,54 +1,46 @@
 #include "emb_ext_flash.h"
 
-// User functions
-int emb_ext_flash_transfer( int id, uint8_t *tx_data, uint8_t *rx_data, uint16_t len )
-{
-    // TODO: User must implement this function
-}
-
-void emb_ext_flash_select( int id, int sel )
-{
-    // TODO: User must implement this function
-}
-
-void emb_ext_flash_delay_us( uint32_t duration )
-{
-    // TODO: User must implement this function
-}
-
 // Private functions
-uint8_t emb_ext_flash_busy( int id )
+uint8_t emb_ext_flash_busy( emb_flash_intf_handle_t *p_intf )
 {
-    return ( emb_ext_flash_get_status( id ) & EXT_FLASH_STATUS_REG_BUSY );
+    return ( emb_ext_flash_get_status( p_intf ) & EXT_FLASH_STATUS_REG_BUSY );
 }
 
-void emb_ext_flash_write_enable( int id )
+void emb_ext_flash_write_enable( emb_flash_intf_handle_t *p_intf )
 {
     // Make the command
     uint8_t cmd = EXT_FLASH_CMD_WRITE_ENABLE;
 
+    // Null check
+    if( !p_intf )
+        return;
+
     // Do the transfer
-    emb_ext_flash_select( id, true );
-    emb_ext_flash_transfer( id, &cmd, 0, 1 );
-    emb_ext_flash_select( id, false );
+    p_intf->select();
+    p_intf->write( &cmd, 1 );
+    p_intf->deselect();
 
     // Block while the WEL bit in the status register is unset
-    while( !( emb_ext_flash_get_status( id ) & EXT_FLASH_STATUS_REG_WEL ) )
+    while( !( emb_ext_flash_get_status( p_intf ) & EXT_FLASH_STATUS_REG_WEL ) )
         ;
 }
 
 // Pubic functions
-int emb_ext_flash_get_jedec_id( int id, uint8_t *manufacturer_id, uint8_t *memory_type, uint8_t *capacity )
+int emb_ext_flash_get_jedec_id( emb_flash_intf_handle_t *p_intf, uint8_t *manufacturer_id, uint8_t *memory_type, uint8_t *capacity )
 {
     // Build the command and the payload
     uint8_t cmd = EXT_FLASH_CMD_JEDEC_ID;
     uint8_t data[3] = { 0 };
 
+    // Null check
+    if( !p_intf )
+        return -1;
+
     // Do the transfer
-    emb_ext_flash_select( id, true );
-    emb_ext_flash_transfer( id, &cmd, 0, 1 );
-    int rtn = emb_ext_flash_transfer( id, 0, data, sizeof( data ) );
-    emb_ext_flash_select( id, false );
+    p_intf->select();
+    p_intf->write( &cmd, 1 );
+    int rtn = p_intf->read( data, 3 );
+    p_intf->deselect();
 
     // Populate the fields
     *manufacturer_id = data[0];
@@ -56,50 +48,62 @@ int emb_ext_flash_get_jedec_id( int id, uint8_t *manufacturer_id, uint8_t *memor
     *capacity = data[2];
 
     // Return 0 for non error, -1 for error
-    return rtn == 3 ? 0 : -1;
+    return rtn;
 }
 
-int emb_ext_flash_read( int id, uint32_t address, uint8_t *data, uint16_t len )
+int emb_ext_flash_read( emb_flash_intf_handle_t *p_intf, uint32_t address, uint8_t *data, uint16_t len )
 {
     // Build the command
     uint8_t cmd[4] = { EXT_FLASH_CMD_READ_DATA, ( address >> 16 ) & 0xFF, ( address >> 8 ) & 0xFF, address & 0xFF };
 
+    // Null check
+    if( !p_intf )
+        return 0;
+
     // Do the transfer
-    emb_ext_flash_select( id, true );
-    emb_ext_flash_transfer( id, cmd, 0, sizeof( cmd ) );
-    int rtn = emb_ext_flash_transfer( id, 0, data, len );
-    emb_ext_flash_select( id, false );
+    p_intf->select();
+    p_intf->write( cmd, sizeof( cmd ) );
+    int rtn = p_intf->read( data, len );
+    p_intf->deselect();
 
     // Return the number of bytes read
-    return rtn;
+    return ( rtn == 0 ? len : 0 );
 }
 
-int emb_ext_flash_write( int id, uint32_t address, uint8_t *data, uint16_t len )
+int emb_ext_flash_write( emb_flash_intf_handle_t *p_intf, uint32_t address, uint8_t *data, uint16_t len )
 {
     // Enable writes
-    emb_ext_flash_write_enable( id );
+    emb_ext_flash_write_enable( p_intf );
 
     // Build the command
     uint8_t cmd[4] = { EXT_FLASH_CMD_PAGE_PROGRAM, ( address >> 16 ) & 0xFF, ( address >> 8 ) & 0xFF, address & 0xFF };
 
+    // Null check
+    if( !p_intf )
+        return 0;
+
     // Do the transfer
-    emb_ext_flash_select( id, true );
-    emb_ext_flash_transfer( id, cmd, 0, sizeof( cmd ) );
-    int rtn = emb_ext_flash_transfer( id, data, 0, len );
-    emb_ext_flash_select( id, false );
+    p_intf->select();
+    p_intf->write( cmd, sizeof( cmd ) );
+    int rtn = p_intf->write( data, len );
+    p_intf->deselect();
 
     // Block while the flash chip commits the write
-    while( emb_ext_flash_busy( id ) )
+    while( emb_ext_flash_busy( p_intf ) )
         ;
 
     // Return the number of bytes written
-    return rtn;
+    return ( rtn == 0 ? len : 0 );
 }
 
-int emb_ext_flash_erase( int id, uint32_t address, uint32_t len )
+int emb_ext_flash_erase( emb_flash_intf_handle_t *p_intf, uint32_t address, uint32_t len )
 {
     // Enable writes
-    emb_ext_flash_write_enable( id );
+    emb_ext_flash_write_enable( p_intf );
+
+    // Null check
+    if( !p_intf )
+        return -1;
 
     // Determine the most efficient command to use
     uint8_t type = EXT_FLASH_CMD_SECTOR_ERASE;
@@ -112,78 +116,97 @@ int emb_ext_flash_erase( int id, uint32_t address, uint32_t len )
     uint8_t cmd[4] = { type, ( address >> 16 ) & 0xFF, ( address >> 8 ) & 0xFF, address & 0xFF };
 
     // Do the transfer
-    emb_ext_flash_select( id, true );
-    int rtn = emb_ext_flash_transfer( id, cmd, 0, 4 );
-    emb_ext_flash_select( id, false );
+    p_intf->select();
+    int rtn = p_intf->write( cmd, sizeof( cmd ) );
+    p_intf->deselect();
 
     // Block while the erase is committed
-    while( emb_ext_flash_busy( id ) )
+    while( emb_ext_flash_busy( p_intf ) )
         ;
 
     // Return 0 if successful -1 otherwise
-    return rtn == 4 ? 0 : -1;
+    return rtn;
 }
 
-void emb_ext_flash_chip_erase( int id )
+int emb_ext_flash_chip_erase( emb_flash_intf_handle_t *p_intf )
 {
     // Enable writes
-    emb_ext_flash_write_enable( id );
+    emb_ext_flash_write_enable( p_intf );
+
+    // Null check
+    if( !p_intf )
+        return;
 
     // Build the command
     uint8_t cmd = EXT_FLASH_CMD_CHIP_ERASE;
 
     // Do the transfer
-    emb_ext_flash_select( id, true );
-    emb_ext_flash_transfer( id, &cmd, 0, 1 );
-    emb_ext_flash_select( id, false );
+    p_intf->select();
+    int rtn = p_intf->write( &cmd, 1 );
+    p_intf->deselect();
 
     // Block while the erase is committed - this can take 2 minutes + on a chip a erase
-    while( emb_ext_flash_busy( id ) )
+    while( emb_ext_flash_busy( p_intf ) )
         ;
+
+    // Return 0 if successful -1 otherwise
+    return rtn;
 }
 
-uint8_t emb_ext_flash_get_status( int id )
+uint8_t emb_ext_flash_get_status( emb_flash_intf_handle_t *p_intf )
 {
     // Build the command
     uint8_t cmd = EXT_FLASH_CMD_READ_STATUS_REG;
     uint8_t status = 0;
 
+    // Null check
+    if( !p_intf )
+        return status;
+
     // Do the transfer
-    emb_ext_flash_select( id, true );
-    emb_ext_flash_transfer( id, &cmd, 0, 1 );
-    emb_ext_flash_transfer( id, 0, &status, 1 );
-    emb_ext_flash_select( id, false );
+    p_intf->select();
+    p_intf->write( &cmd, 1 );
+    p_intf->read( &status, 1 );
+    p_intf->deselect();
 
     // Return the status
     return status;
 }
 
-int emb_ext_flash_sleep( int id )
+int emb_ext_flash_sleep( emb_flash_intf_handle_t *p_intf )
 {
     // Build the  command
     uint8_t cmd = EXT_FLASH_CMD_POWER_DOWN;
 
-    // Do the transfer
-    emb_ext_flash_select( id, true );
-    int rtn = emb_ext_flash_transfer( id, &cmd, 0, 1 );
-    emb_ext_flash_select( id, false );
+    // Null check
+    if( !p_intf )
+        return -1;
 
-    return rtn == 1 ? 0 : -1;
+    // Do the transfer
+    p_intf->select();
+    int rtn = p_intf->write( &cmd, 1 );
+    p_intf->deselect();
+
+    return rtn;
 }
 
-int emb_ext_flash_wake( int id )
+int emb_ext_flash_wake( emb_flash_intf_handle_t *p_intf )
 {
     // Build the command
     uint8_t cmd = EXT_FLASH_CMD_RELEASE_POWER_DOWN;
 
+    // Null check
+    if( !p_intf )
+        return -1;
+
     // Do the transfer
-    emb_ext_flash_select( id, true );
-    int rtn = emb_ext_flash_transfer( id, &cmd, 0, 1 );
-    emb_ext_flash_select( id, false );
+    p_intf->select();
+    int rtn = p_intf->write( &cmd, 1 );
+    p_intf->deselect();
 
     // Wait for the specified duration for wake time - this can be optimized to your use case.
-    emb_ext_flash_delay_us( 3 );
+    p_intf->delay_us( 3 );
 
     // Return 0 for success -1 otherwise.
-    return rtn == 1 ? 0 : -1;
+    return rtn;
 }

--- a/src/emb_ext_flash.c
+++ b/src/emb_ext_flash.c
@@ -52,7 +52,7 @@ int emb_ext_flash_get_jedec_id( emb_flash_intf_handle_t *p_intf, uint8_t *manufa
     uint8_t data[3] = { 0 };
 
     // Null check
-    if( !p_intf || !p_intf->initialized )
+    if( !p_intf || !p_intf->initialized || !manufacturer_id || !memory_type || !capacity )
         return -1;
 
     // Do the transfer
@@ -76,7 +76,7 @@ int emb_ext_flash_read( emb_flash_intf_handle_t *p_intf, uint32_t address, uint8
     uint8_t cmd[4] = { EXT_FLASH_CMD_READ_DATA, ( address >> 16 ) & 0xFF, ( address >> 8 ) & 0xFF, address & 0xFF };
 
     // Null check
-    if( !p_intf || !p_intf->initialized )
+    if( !p_intf || !p_intf->initialized || !data || !len )
         return 0;
 
     // Do the transfer
@@ -98,7 +98,7 @@ int emb_ext_flash_write( emb_flash_intf_handle_t *p_intf, uint32_t address, uint
     uint8_t cmd[4] = { EXT_FLASH_CMD_PAGE_PROGRAM, ( address >> 16 ) & 0xFF, ( address >> 8 ) & 0xFF, address & 0xFF };
 
     // Null check
-    if( !p_intf || !p_intf->initialized )
+    if( !p_intf || !p_intf->initialized || !data || !len )
         return 0;
 
     // Do the transfer

--- a/src/emb_ext_flash.h
+++ b/src/emb_ext_flash.h
@@ -34,6 +34,8 @@ extern "C" {
  */
 typedef struct
 {
+    // Flag to indicate if the interface handle has been initialized.
+    uint8_t initialized;
     // Function pointer to select the external flash memory chip.
     void ( *select )();
     // Function point to deselec the external flash memory chip.
@@ -45,6 +47,16 @@ typedef struct
     // Function pointer to delay for a specified duration in microseconds.
     void ( *delay_us )( uint32_t duration );
 } emb_flash_intf_handle_t;
+
+/**
+ * @brief emb_ext_flash_init_intf - initialize the interface handle, this function must be called before any other functions
+ * for each interface handle. All this does is check each function pointer for a null value and returns -1 if any are null.
+ * Otherwise it sets the initialized flag to 1 and returns 0.
+ *
+ * @param p_intf - pointer to the interface handle.
+ * @return int - 0 on success, -1 on failure.
+ */
+int emb_ext_flash_init_intf( emb_flash_intf_handle_t *p_intf );
 
 /**
  * @brief emb_ext_flash_get_jedec_id get the JEDEC ID of the external flash memory chip.

--- a/src/emb_ext_flash.h
+++ b/src/emb_ext_flash.h
@@ -28,106 +28,98 @@ extern "C" {
 #define EXT_FLASH_STATUS_REG_WEL 0x02
 
 /**
- * @brief emb_ext_flash_transfer exchange bytes with the external flash memory chip, this function must be implemented by the user.
- * The function is intentionally left ambiguous to support mulitple interfaces, including but not limited to SPI, UART, I2C, etc.
- *
- * @param id - the id of the external flash memory chip, this is used to support multiple chips. The ID is arbitrary and is set by the user.
- * @param tx_data - pointer to the data to be sent to the external flash memory chip.
- * @param rx_data - pointer to the data to be received from the external flash memory chip.
- * @param len - the number of bytes to be sent and received.
- * @return int - number of bytes successfully transferred.
+ * @brief emb_flash_intf_handle_t - structure to hold the interface functions for the external flash memory chip.
+ * This structure is used to hold the function pointers to the interface functions for the external flash memory chip.
+ * The functions are intentionally left ambiguous to support mulitple interfaces, including but not limited to SPI, UART, I2C, etc.
  */
-int emb_ext_flash_transfer( int id, uint8_t *tx_data, uint8_t *rx_data, uint16_t len );
-
-/**
- * @brief emb_ext_flash_select select the external flash memory chip, this function must be implemented by the user.
- * If the chip isn't an SPI chip, this function can be left empty.
- *
- * @param id - the id of the external flash memory chip, this is used to support multiple chips. The ID is arbitrary and is set by the user.
- * @param sel - 1 to select the chip, 0 to de-select the chip.
- */
-void emb_ext_flash_select( int id, int sel );
-
-/**
- * @brief emb_ext_flash_delay_us delay for a specified duration in microseconds, this function must be implemented by the user.
- *
- * @param duration - the number of microseconds to delay.
- */
-void emb_ext_flash_delay_us( uint32_t duration );
+typedef struct
+{
+    // Function pointer to select the external flash memory chip.
+    void ( *select )();
+    // Function point to deselec the external flash memory chip.
+    void ( *deselect )();
+    // Function pointer to write bytes to the external flash memory chip, returns 0 if successful, -1 if not.
+    int ( *write )( uint8_t *data, uint16_t len );
+    // Function pointer to read bytes from the external flash memory chip, returns 0 if successful, -1 if not.
+    int ( *read )( uint8_t *data, uint16_t len );
+    // Function pointer to delay for a specified duration in microseconds.
+    void ( *delay_us )( uint32_t duration );
+} emb_flash_intf_handle_t;
 
 /**
  * @brief emb_ext_flash_get_jedec_id get the JEDEC ID of the external flash memory chip.
  *
- * @param id - the id of the external flash memory chip, this is used to support multiple chips. The ID is arbitrary and is set by the user.
+ * @param p_intf - pointer to the interface handle.
  * @param manufacturer_id - pointer to the manufacturer ID to be read.
  * @param memory_type - pointer to the memory type to be read.
  * @param capacity - pointer to the capacity to be read.
  * @return int - 0 on success, -1 on failure.
  */
-int emb_ext_flash_get_jedec_id( int id, uint8_t *manufacturer_id, uint8_t *memory_type, uint8_t *capacity );
+int emb_ext_flash_get_jedec_id( emb_flash_intf_handle_t *p_intf, uint8_t *manufacturer_id, uint8_t *memory_type, uint8_t *capacity );
 
 /**
  * @brief emb_ext_flash_read read data from the external flash memory chip.
  *
- * @param id - the id of the external flash memory chip, this is used to support multiple chips. The ID is arbitrary and is set by the user.
+ * @param p_intf - pointer to the interface handle.
  * @param address - the address to read from.
  * @param data - pointer to the data to be read.
  * @param len - the number of bytes to be read.
  * @return int - number of bytes successfully read.
  */
-int emb_ext_flash_read( int id, uint32_t address, uint8_t *data, uint16_t len );
+int emb_ext_flash_read( emb_flash_intf_handle_t *p_intf, uint32_t address, uint8_t *data, uint16_t len );
 
 /**
  * @brief emb_ext_flash_write write data to the external flash memory chip.
  *
- * @param id - the id of the external flash memory chip, this is used to support multiple chips. The ID is arbitrary and is set by the user.
+ * @param p_intf - pointer to the interface handle.
  * @param address - the address to write to.
  * @param data - pointer to the data to be written.
  * @param len - the number of bytes to be written.
  * @return int - number of bytes successfully written.
  */
-int emb_ext_flash_write( int id, uint32_t address, uint8_t *data, uint16_t len );
+int emb_ext_flash_write( emb_flash_intf_handle_t *p_intf, uint32_t address, uint8_t *data, uint16_t len );
 
 /**
  * @brief emb_ext_flash_erase erase the external flash memory chip.
  *
- * @param id - the id of the external flash memory chip, this is used to support multiple chips. The ID is arbitrary and is set by the user.
+ * @param p_intf - pointer to the interface handle.
  * @param address - the address to erase from.
  * @param len - the number of bytes to be erased.
  * @return int - 0 on success, -1 on failure.
  */
-int emb_ext_flash_erase( int id, uint32_t address, uint32_t len );
+int emb_ext_flash_erase( emb_flash_intf_handle_t *p_intf, uint32_t address, uint32_t len );
 
 /**
  * @brief emb_ext_flash_chip_erase erase the entire external flash memory chip.
  *
- * @param id - the id of the external flash memory chip, this is used to support multiple chips. The ID is arbitrary and is set by the user.
+ * @param p_intf - pointer to the interface handle.
+ * @return int - 0 on success, -1 on failure.
  */
-void emb_ext_flash_chip_erase( int id );
+int emb_ext_flash_chip_erase( emb_flash_intf_handle_t *p_intf );
 
 /**
  * @brief emb_ext_flash_get_status read the status register of the external flash memory chip.
  *
- * @param id - the id of the external flash memory chip, this is used to support multiple chips. The ID is arbitrary and is set by the user.
+ * @param p_intf - pointer to the interface handle.
  * @return uint8_t - the status register value.
  */
-uint8_t emb_ext_flash_get_status( int id );
+uint8_t emb_ext_flash_get_status( emb_flash_intf_handle_t *p_intf );
 
 /**
  * @brief emb_ext_flash_sleep put the external flash memory chip into sleep mode.
  *
- * @param id - the id of the external flash memory chip, this is used to support multiple chips. The ID is arbitrary and is set by the user.
+ * @param p_intf - pointer to the interface handle.
  * @return int - 0 on success, -1 on failure.
  */
-int emb_ext_flash_sleep( int id );
+int emb_ext_flash_sleep( emb_flash_intf_handle_t *p_intf );
 
 /**
  * @brief emb_ext_flash_wake wake the external flash memory chip from sleep mode.
  *
- * @param id - the id of the external flash memory chip, this is used to support multiple chips. The ID is arbitrary and is set by the user.
+ * @param p_intf - pointer to the interface handle.
  * @return int - 0 on success, -1 on failure.
  */
-int emb_ext_flash_wake( int id );
+int emb_ext_flash_wake( emb_flash_intf_handle_t *p_intf );
 
 #ifdef __cplusplus
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.14)
+project(test)
+
+# GoogleTest requires at least C++14
+set(CMAKE_CXX_STANDARD 14)
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG release-1.12.1
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+enable_testing()
+
+include_directories("../src")
+
+add_compile_definitions(UNIT_TEST_FRAMEWORK)
+
+file(GLOB sources
+  "../src/*.h"
+  "../src/*.c"
+  "*.c")
+
+add_executable(
+  emb_ext_flash_test
+  emb_ext_flash_test.cc
+  ${sources}
+)
+
+target_link_libraries(
+  emb_ext_flash_test
+  GTest::gtest_main
+)
+
+include(GoogleTest)
+gtest_discover_tests(emb_ext_flash_test)

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,14 @@
+# About
+This is the unit test module for the C implementation of the embedded external flash memory. We leverage the google test framework for compartmentalized unit testing for the interface implementation. For unit testing purposes we have created a simulated flash memory bank that occupies space in RAM. You can read more about the google test framework here: https://github.com/google/googletest.
+
+# Dependencies
+You will only need dependencies for the google test framework to run these unit tests - all release versions are passing unit tests.
+
+# Run
+To run the unit test framework run the following commands out of this directory:
+```
+rm -rf build
+cmake -S . -B build
+cmake --build build
+./build/protocol_test
+```

--- a/test/emb_ext_flash_test.cc
+++ b/test/emb_ext_flash_test.cc
@@ -1,36 +1,443 @@
 #include <gtest/gtest.h>
 #include <emb_ext_flash.h>
 
+// Flash simulation JEDEC ID
+#define FLASH_SIM_JEDEC_ID 0x1F4401
+
+// Flash simulation memory size
+#define FLASH_SIM_MEM_SIZE 0x40000
+
+// Flash sim memory bank, default to 0xFF
+uint8_t _flash_sim_mem[FLASH_SIM_MEM_SIZE] = { 0xFF };
+
+// Flash simulation state enumaration
+enum flash_sim_state
+{
+    FLASH_SIM_STATE_IDLE,
+    FLASH_SIM_SET_ADDR,
+    FLASH_SIM_STATE_READ,
+    FLASH_SIM_STATE_WRITE,
+    FLASH_SIM_STATUS_REG_READ,
+    FLASH_SIM_STATUS_REG_WRITE,
+    FLASH_SIM_ERASE,
+    FLASH_SIM_GET_JEDEC_ID,
+};
+
+// Flash simulation state
+int _flash_sim_state = FLASH_SIM_STATE_IDLE;
+
+// Flash simulation current address
+uint32_t _flash_sim_addr = 0;
+
+// Flash simulation write enable latch
+bool _flash_sim_wel = false;
+
+// Flash simulation status register
+uint8_t _flash_sim_status_reg = 0;
+
+// Flash simulation erase length setting
+uint32_t _flash_sim_erase_len = 0;
+
+// Parse the command, return 0 if successful, -1 if not.
+int flash_sim_parse_cmd( uint8_t cmd )
+{
+    // Switch based on the command
+    switch( cmd ) {
+        case EXT_FLASH_CMD_WRITE_ENABLE:
+            // Set the write enable latch
+            _flash_sim_wel = true;
+            // Set the state to address setting
+            _flash_sim_state = FLASH_SIM_SET_ADDR;
+            // Set the status register to EXT_FLASH_STATUS_REG_WEL
+            _flash_sim_status_reg |= EXT_FLASH_STATUS_REG_WEL;
+            break;
+        case EXT_FLASH_CMD_WRITE_DISABLE:
+            // Clear the write enable latch
+            _flash_sim_wel = false;
+            break;
+        case EXT_FLASH_CMD_READ_STATUS_REG:
+            // Set the state to read the status register
+            _flash_sim_state = FLASH_SIM_STATUS_REG_READ;
+            break;
+        case EXT_FLASH_CMD_WRITE_STATUS_REG:
+            // Set the state to write the status register
+            _flash_sim_state = FLASH_SIM_STATUS_REG_WRITE;
+            break;
+        case EXT_FLASH_CMD_READ_DATA:
+            // Set the state to address setting
+            _flash_sim_state = FLASH_SIM_SET_ADDR;
+            break;
+        case EXT_FLASH_CMD_FAST_READ:
+            // Set the state to address setting
+            _flash_sim_state = FLASH_SIM_SET_ADDR;
+            break;
+        case EXT_FLASH_CMD_PAGE_PROGRAM:
+            // If write enable latch is set, set the state to address setting, otherwise just ignore the command
+            if( _flash_sim_wel ) {
+                _flash_sim_state = FLASH_SIM_SET_ADDR;
+            }
+            else {
+                _flash_sim_state = FLASH_SIM_STATE_IDLE;
+            }
+            break;
+        case EXT_FLASH_CMD_SECTOR_ERASE:
+            // If write enable latch is set, set the state to address setting, otherwise just ignore the command
+            if( _flash_sim_wel ) {
+                _flash_sim_state = FLASH_SIM_SET_ADDR;
+                _flash_sim_erase_len = 4096;
+            }
+            else {
+                _flash_sim_state = FLASH_SIM_STATE_IDLE;
+                _flash_sim_erase_len = 0;
+            }
+            break;
+        case EXT_FLASH_CMD_BLOCK_ERASE_32K:
+            // If write enable latch is set, set the state to address setting, otherwise just ignore the command
+            if( _flash_sim_wel ) {
+                _flash_sim_state = FLASH_SIM_SET_ADDR;
+                _flash_sim_erase_len = 32768;
+            }
+            else {
+                _flash_sim_state = FLASH_SIM_STATE_IDLE;
+                _flash_sim_erase_len = 0;
+            }
+            break;
+        case EXT_FLASH_CMD_BLOCK_ERASE_64K:
+            // If write enable latch is set, set the state to address setting, otherwise just ignore the command
+            if( _flash_sim_wel ) {
+                _flash_sim_state = FLASH_SIM_SET_ADDR;
+                _flash_sim_erase_len = 65536;
+            }
+            else {
+                _flash_sim_state = FLASH_SIM_STATE_IDLE;
+                _flash_sim_erase_len = 0;
+            }
+            break;
+        case EXT_FLASH_CMD_CHIP_ERASE:
+            // If write enable latch is set, set the state to address setting, otherwise just ignore the command
+            if( _flash_sim_wel ) {
+                _flash_sim_state = FLASH_SIM_SET_ADDR;
+                _flash_sim_erase_len = FLASH_SIM_MEM_SIZE;
+            }
+            else {
+                _flash_sim_state = FLASH_SIM_STATE_IDLE;
+                _flash_sim_erase_len = 0;
+            }
+            break;
+        case EXT_FLASH_CMD_POWER_DOWN:
+            // Do nothing
+            break;
+        case EXT_FLASH_CMD_RELEASE_POWER_DOWN:
+            // Do nothing
+            break;
+        case EXT_FLASH_CMD_JEDEC_ID:
+            // Set the state to get the JEDEC ID
+            _flash_sim_state = FLASH_SIM_GET_JEDEC_ID;
+            break;
+        default:
+            // Unknown command, set to IDLE
+            _flash_sim_state = FLASH_SIM_STATE_IDLE;
+            // Return an error
+            return -1;
+    }
+    // Return success
+    return 0;
+}
+
+// Flash simulation address setter
+int flash_sim_set_addr( uint8_t next_byte )
+{
+    // Each address is 3 bytes long, passed in a byte at a time. The first byte is the most significant byte.
+    // The address is stored in the flash_sim_addr variable.
+    // Shift the address left by 8 bits and add the next byte, if its the first byte, clear the address first.
+    static uint8_t addr_byte = 0;
+    if( addr_byte == 0 ) {
+        _flash_sim_addr = 0;
+    }
+    _flash_sim_addr = ( _flash_sim_addr << 8 ) | next_byte;
+    addr_byte++;
+
+    // If the address is 3 bytes long, return success
+    if( addr_byte == 3 ) {
+        addr_byte = 0;
+        return 0;
+    }
+
+    // Otherwise return failure
+    return -1;
+}
+
+// Flash simulation jedec id getter
+uint8_t flash_sim_get_jedec_id( void )
+{
+    // The jedec id is a 3 byte value. Return the next byte in the sequence, and reset the state when done.
+    static uint8_t jedec_id_byte = 0;
+    uint8_t        ret = FLASH_SIM_JEDEC_ID >> ( 8 * ( 2 - jedec_id_byte++ ) );
+    if( jedec_id_byte == 3 ) {
+        jedec_id_byte = 0;
+    }
+    return ret;
+}
+
+// Flash simulation state machine
+uint8_t flash_sim_sm( uint8_t next_byte )
+{
+    // Switch based on the state
+    switch( _flash_sim_state ) {
+        case FLASH_SIM_STATE_IDLE:
+            // Parse the command, regardless of the result return 0xFF
+            flash_sim_parse_cmd( next_byte );
+            return 0xFF;
+            break;
+        case FLASH_SIM_SET_ADDR:
+            // Parse the address, if its successful set the state to read or write depending on the WEL, return 0xFF regardless
+            if( flash_sim_set_addr( next_byte ) == 0 ) {
+                if( _flash_sim_wel && _flash_sim_erase_len == 0 ) {
+                    _flash_sim_state = FLASH_SIM_STATE_WRITE;
+                }
+                else if( _flash_sim_wel && _flash_sim_erase_len > 0 ) {
+                    _flash_sim_state = FLASH_SIM_ERASE;
+                }
+                else {
+                    _flash_sim_state = FLASH_SIM_STATE_READ;
+                }
+            }
+            return 0xFF;
+            break;
+        case FLASH_SIM_STATE_READ:
+            // Return the next byte of the read
+            return _flash_sim_mem[_flash_sim_addr++];
+            break;
+        case FLASH_SIM_STATE_WRITE:
+            // Write the next byte to the memory by AND'ing it with the byte
+            _flash_sim_mem[_flash_sim_addr++] &= next_byte;
+            // Make sure the status byte is set to write in progress
+            _flash_sim_status_reg |= EXT_FLASH_STATUS_REG_BUSY;
+            // Clear the WEL in the status register
+            _flash_sim_status_reg &= ~EXT_FLASH_STATUS_REG_WEL;
+            return 0xFF;
+            break;
+        case FLASH_SIM_STATUS_REG_READ:
+            // Return the status register
+            return _flash_sim_status_reg;
+            break;
+        case FLASH_SIM_STATUS_REG_WRITE:
+            // Write the next byte to the status register
+            _flash_sim_status_reg = next_byte;
+            break;
+        case FLASH_SIM_GET_JEDEC_ID:
+            // Return the next byte of the JEDEC ID
+            return flash_sim_get_jedec_id();
+            break;
+        case FLASH_SIM_ERASE:
+            // Erase the address space specified by the current address and the erase length
+            memset( &_flash_sim_mem[_flash_sim_addr], 0xFF, _flash_sim_erase_len );
+            // Set the status register to busy
+            _flash_sim_status_reg |= EXT_FLASH_STATUS_REG_BUSY;
+            // Clear the WEL in the status register
+            _flash_sim_status_reg &= ~EXT_FLASH_STATUS_REG_WEL;
+            break;
+        default:
+            // Unknown state, set to IDLE
+            _flash_sim_state = FLASH_SIM_STATE_IDLE;
+            break;
+    }
+
+    // Return the next byte to send
+    return 0xFF;
+}
+
+// Interface "selected" flag
+bool _is_selected = false;
+
+// Interface select method
+void _select()
+{
+    _is_selected = true;
+}
+
+// Interface deselect method
+void _deselect()
+{
+    _is_selected = false;
+    // Set the state to idle
+    _flash_sim_state = FLASH_SIM_STATE_IDLE;
+    // Set the erase length to 0
+    _flash_sim_erase_len = 0;
+    // Set the WEL to false
+    _flash_sim_wel = false;
+    // Clear the busy bit in the status register
+    _flash_sim_status_reg &= ~EXT_FLASH_STATUS_REG_BUSY;
+    // Set the address to 0
+    _flash_sim_addr = 0;
+}
+
+// Interface buffer write method, returns 0 if successful, -1 if not.
+int _write( uint8_t *data, uint16_t len )
+{
+    // Run the flash simulation state machine for each byte in the buffer
+    for( uint16_t i = 0; i < len; i++ ) {
+        flash_sim_sm( data[i] );
+    }
+    return 0;
+}
+
+// Interface buffer read method, returns 0 if successful, -1 if not.
+int _read( uint8_t *data, uint16_t len )
+{
+    // Run the flash simulation state machine for each byte in the buffer
+    for( uint16_t i = 0; i < len; i++ ) {
+        data[i] = flash_sim_sm( 0xFF );
+    }
+    return 0;
+}
+
+// Interface delay method for a specified duration in microseconds.
+void _delay_us( uint32_t duration )
+{
+    // Do nothing
+}
+
+// Make a global interface struct
+emb_flash_intf_handle_t _intf = {
+    false,
+    _select,
+    _deselect,
+    _write,
+    _read,
+    _delay_us };
+
 // Class for facilitating embedded external flash memory tests
 class emb_ext_flash_test : public ::testing::Test
 {
-public:
-  emb_ext_flash_test()
-  {
-    // initialization code here
-  }
+  public:
+    emb_ext_flash_test()
+    {
+        // initialization code here
+    }
 
-  void SetUp()
-  {
-    // code here will execute just before the test ensues
-  }
+    void SetUp()
+    {
+        // code here will execute just before the test ensues
+        // Force the interface struct to pass through
+        emb_ext_flash_init_intf( &_intf );
+        // Deselect the interface
+        _intf.deselect();
+    }
 
-  void TearDown()
-  {
-    // code here will be called just after the test completes
-    // ok to through exceptions from here if need be
-  }
+    void TearDown()
+    {
+        // code here will be called just after the test completes
+        // ok to through exceptions from here if need be
+    }
 
-  ~emb_ext_flash_test()
-  {
-    // cleanup any pending stuff, but no exceptions allowed
-  }
+    ~emb_ext_flash_test()
+    {
+        // cleanup any pending stuff, but no exceptions allowed
+    }
 
-  // put in any custom data members that you need
+    // put in any custom data members that you need
 };
 
-TEST_F(emb_ext_flash_test, test1)
+TEST_F( emb_ext_flash_test, test_null_init )
 {
-  // test code here
-  ASSERT_TRUE(true);
+    // Test null initialization
+    ASSERT_EQ( emb_ext_flash_init_intf( NULL ), -1 );
+
+    // Test null interface
+    emb_flash_intf_handle_t intf = { 0 };
+    ASSERT_EQ( emb_ext_flash_init_intf( &intf ), -1 );
+
+    // Build a complete interface struct
+    emb_flash_intf_handle_t intf2 = {
+        false,
+        _select,
+        _deselect,
+        _write,
+        _read,
+        _delay_us };
+
+    // Test null select method
+    intf2.select = NULL;
+    ASSERT_EQ( emb_ext_flash_init_intf( &intf2 ), -1 );
+    ASSERT_FALSE( intf2.initialized );
+    intf2.select = _select;
+
+    // Test null deselect method
+    intf2.deselect = NULL;
+    ASSERT_EQ( emb_ext_flash_init_intf( &intf2 ), -1 );
+    ASSERT_FALSE( intf2.initialized );
+    intf2.deselect = _deselect;
+
+    // Test null write method
+    intf2.write = NULL;
+    ASSERT_EQ( emb_ext_flash_init_intf( &intf2 ), -1 );
+    ASSERT_FALSE( intf2.initialized );
+    intf2.write = _write;
+
+    // Test null read method
+    intf2.read = NULL;
+    ASSERT_EQ( emb_ext_flash_init_intf( &intf2 ), -1 );
+    ASSERT_FALSE( intf2.initialized );
+    intf2.read = _read;
+
+    // Test null delay method
+    intf2.delay_us = NULL;
+    ASSERT_EQ( emb_ext_flash_init_intf( &intf2 ), -1 );
+    ASSERT_FALSE( intf2.initialized );
+    intf2.delay_us = _delay_us;
+}
+
+TEST_F( emb_ext_flash_test, test_init )
+{
+    // Test initialization
+    _intf.initialized = false;
+    ASSERT_EQ( emb_ext_flash_init_intf( &_intf ), 0 );
+    ASSERT_TRUE( _intf.initialized );
+}
+
+TEST_F( emb_ext_flash_test, test_null_intf_checks )
+{
+    // Test jedec id check
+    ASSERT_EQ( emb_ext_flash_get_jedec_id( NULL, NULL, NULL, NULL ), -1 );
+    ASSERT_EQ( emb_ext_flash_get_jedec_id( &_intf, NULL, NULL, NULL ), -1 );
+    uint8_t manufacturer_id = 0;
+    ASSERT_EQ( emb_ext_flash_get_jedec_id( &_intf, &manufacturer_id, NULL, NULL ), -1 );
+    uint8_t memory_type = 0;
+    ASSERT_EQ( emb_ext_flash_get_jedec_id( &_intf, &manufacturer_id, &memory_type, NULL ), -1 );
+
+    // Test read checks
+    ASSERT_EQ( emb_ext_flash_read( NULL, 0, NULL, 0 ), 0 );
+    ASSERT_EQ( emb_ext_flash_read( &_intf, 0, NULL, 0 ), 0 );
+
+    // Test write checks
+    ASSERT_EQ( emb_ext_flash_write( NULL, 0, NULL, 0 ), 0 );
+    ASSERT_EQ( emb_ext_flash_write( &_intf, 0, NULL, 0 ), 0 );
+
+    // Test erase checks
+    ASSERT_EQ( emb_ext_flash_erase( NULL, 0, 0 ), -1 );
+
+    // Test chip erase checks
+    ASSERT_EQ( emb_ext_flash_chip_erase( NULL ), -1 );
+
+    // Test status register checks
+    ASSERT_EQ( emb_ext_flash_get_status( NULL ), 0 );
+
+    // Test write sleep checks
+    ASSERT_EQ( emb_ext_flash_sleep( NULL ), -1 );
+
+    // Test wake checks
+    ASSERT_EQ( emb_ext_flash_wake( NULL ), -1 );
+}
+
+TEST_F( emb_ext_flash_test, test_jedec_id )
+{
+    // Test jedec id against the simulator
+    uint8_t manufacturer_id = 0;
+    uint8_t memory_type = 0;
+    uint8_t capacity = 0;
+    ASSERT_EQ( emb_ext_flash_get_jedec_id( &_intf, &manufacturer_id, &memory_type, &capacity ), 0 );
+    ASSERT_EQ( manufacturer_id, FLASH_SIM_JEDEC_ID >> 16 );
+    ASSERT_EQ( memory_type, ( FLASH_SIM_JEDEC_ID >> 8 ) & 0xFF );
+    ASSERT_EQ( capacity, FLASH_SIM_JEDEC_ID & 0xFF );
 }

--- a/test/emb_ext_flash_test.cc
+++ b/test/emb_ext_flash_test.cc
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+#include <emb_ext_flash.h>
+
+// Class for facilitating embedded external flash memory tests
+class emb_ext_flash_test : public ::testing::Test
+{
+public:
+  emb_ext_flash_test()
+  {
+    // initialization code here
+  }
+
+  void SetUp()
+  {
+    // code here will execute just before the test ensues
+  }
+
+  void TearDown()
+  {
+    // code here will be called just after the test completes
+    // ok to through exceptions from here if need be
+  }
+
+  ~emb_ext_flash_test()
+  {
+    // cleanup any pending stuff, but no exceptions allowed
+  }
+
+  // put in any custom data members that you need
+};
+
+TEST_F(emb_ext_flash_test, test1)
+{
+  // test code here
+  ASSERT_TRUE(true);
+}


### PR DESCRIPTION
Replaced the `id` field with a handle struct. This allows multiple flash interfaces to be utilized by the library.

Also implemented unit test coverage.